### PR TITLE
[Next.js] Fix use of environment variables for JSS config generation

### DIFF
--- a/src/sxastarter/scripts/generate-config.ts
+++ b/src/sxastarter/scripts/generate-config.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import fs from 'fs';
 import path from 'path';
 import { constantCase } from 'constant-case';


### PR DESCRIPTION
Import `dotenv/config` so that environment variables are picked up in default JSS config generation.