### PR TITLE
update dictionary-service-factory to no longer pass jssAppTempalteId

### DIFF
--- a/src/sxastarter/src/lib/dictionary-service-factory.ts
+++ b/src/sxastarter/src/lib/dictionary-service-factory.ts
@@ -20,11 +20,11 @@ export class DictionaryServiceFactory {
           endpoint: config.graphQLEndpoint,
           apiKey: config.sitecoreApiKey,
           siteName,
-          jssAppTemplateId: '{9ED66404-64C9-4122-90E1-869CB3CEA566}',
           /*
-            The Dictionary Service needs a root item ID in order to fetch dictionary phrases for the current
-            app. If your Sitecore instance only has 1 JSS App, you can specify the root item ID here;
-            otherwise, the service will attempt to figure out the root item for the current JSS App using GraphQL and app name.
+            The Dictionary Service needs a root item ID in order to fetch dictionary phrases for the current app. 
+            When not provided, the service will attempt to figure out the root item for the current JSS App using GraphQL and app name.
+            For SXA site(s) and multisite setup there's no need to specify it - it will be autoresolved.
+            Otherwise, if your Sitecore instance only has 1 JSS App (i.e. in a Sitecore XP setup), you can specify the root item ID here.
             rootItemId: '{GUID}'
           */
         })


### PR DESCRIPTION
Updates the dictionary-service-factory in starter app to no longer use jssAppTempalteId. Since the app root template has been updated on Sitecore side, the Service would be able to resolve app root on its own.

Related to https://github.com/Sitecore/jss/pull/1409