### PR TITLE
Moving saas and sass-alias from devDependencies to dependencies

### DIFF
--- a/src/sxastarter/package-lock.json
+++ b/src/sxastarter/package-lock.json
@@ -18,7 +18,9 @@
         "next": "^13.1.6",
         "next-localization": "^0.12.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "sass": "^1.52.3",
+        "sass-alias": "^1.0.5"
       },
       "devDependencies": {
         "@graphql-codegen/cli": "^1.21.8",
@@ -48,8 +50,6 @@
         "graphql-let": "^0.18.6",
         "npm-run-all": "~4.1.5",
         "prettier": "^2.8.3",
-        "sass": "^1.52.3",
-        "sass-alias": "^1.0.5",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.1.2",
         "typescript": "~4.9.4",
@@ -11640,7 +11640,6 @@
       "version": "1.59.3",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.59.3.tgz",
       "integrity": "sha512-QCq98N3hX1jfTCoUAsF3eyGuXLsY7BCnCEg9qAact94Yc21npG2/mVOqoDvE0fCbWDqiM4WlcJQla0gWG2YlxQ==",
-      "devOptional": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -11656,14 +11655,12 @@
     "node_modules/sass-alias": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sass-alias/-/sass-alias-1.0.5.tgz",
-      "integrity": "sha512-SEXbnha1pL5xseoG7SafOG72nilDNDGQh++G4PaXTlp4NanBFD2IUwPkJzQAGs+2dLPldcoSW8bN12kZwnRQYQ==",
-      "dev": true
+      "integrity": "sha512-SEXbnha1pL5xseoG7SafOG72nilDNDGQh++G4PaXTlp4NanBFD2IUwPkJzQAGs+2dLPldcoSW8bN12kZwnRQYQ=="
     },
     "node_modules/sass/node_modules/immutable": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
-      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
-      "devOptional": true
+      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg=="
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -21910,7 +21907,6 @@
       "version": "1.59.3",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.59.3.tgz",
       "integrity": "sha512-QCq98N3hX1jfTCoUAsF3eyGuXLsY7BCnCEg9qAact94Yc21npG2/mVOqoDvE0fCbWDqiM4WlcJQla0gWG2YlxQ==",
-      "devOptional": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -21920,16 +21916,14 @@
         "immutable": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
-          "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
-          "devOptional": true
+          "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg=="
         }
       }
     },
     "sass-alias": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sass-alias/-/sass-alias-1.0.5.tgz",
-      "integrity": "sha512-SEXbnha1pL5xseoG7SafOG72nilDNDGQh++G4PaXTlp4NanBFD2IUwPkJzQAGs+2dLPldcoSW8bN12kZwnRQYQ==",
-      "dev": true
+      "integrity": "sha512-SEXbnha1pL5xseoG7SafOG72nilDNDGQh++G4PaXTlp4NanBFD2IUwPkJzQAGs+2dLPldcoSW8bN12kZwnRQYQ=="
     },
     "scheduler": {
       "version": "0.23.0",

--- a/src/sxastarter/package.json
+++ b/src/sxastarter/package.json
@@ -44,7 +44,9 @@
     "next": "^13.1.6",
     "next-localization": "^0.12.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+	"sass": "^1.52.3",
+    "sass-alias": "^1.0.5"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^1.21.8",
@@ -73,9 +75,7 @@
     "eslint-plugin-yaml": "^0.5.0",
     "graphql-let": "^0.18.6",
     "npm-run-all": "~4.1.5",
-    "prettier": "^2.8.3",
-    "sass": "^1.52.3",
-    "sass-alias": "^1.0.5",
+    "prettier": "^2.8.3",   
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.1.2",
     "typescript": "~4.9.4",


### PR DESCRIPTION
The `sass` and `sass-alias` packages are used runtime by the "src/sxastarter/src/lib/next-config/plugins/sass.js" plugin. 

Having them in the devDependencies causes the application to crash on some serverless hosts that use production install of npm (aka they trim the devDependencies).