### PR TITLE
I observed that lot of developers are falling in an error where their…

### DIFF
--- a/up.ps1
+++ b/up.ps1
@@ -1,3 +1,7 @@
+# Stop the IIS
+Write-Host "Stopping IIS..." -ForegroundColor Yellow
+iisreset.exe /stop
+
 $ErrorActionPreference = "Stop";
 
 $envContent = Get-Content .env -Encoding UTF8


### PR DESCRIPTION
… computer gets restarted and iis is started again and the upscript which was working just fails after retsart of the computer, so i think there is no harm in brining in iis reset in up script so it first stops it and then proceeeds, if the up script is designed to be run without admin rights then it might not work, but i think things which up scripts do might need admin, but creating a PR and can wait for reviews as i have seen so many people are spending time trying to figure out why something not working after computer restarts