### PR TITLE
Fixed incorrect PublishUrl

### DIFF
--- a/authoring/platform/Properties/PublishProfiles/Local.pubxml
+++ b/authoring/platform/Properties/PublishProfiles/Local.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <LastUsedBuildConfiguration>Debug</LastUsedBuildConfiguration>
     <LastUsedPlatform>Any CPU</LastUsedPlatform>
     <PublishProvider>FileSystem</PublishProvider>
-    <PublishUrl>..\..\..\local-containers\docker\deploy\platform</PublishUrl>
+    <PublishUrl>..\..\local-containers\docker\deploy\platform</PublishUrl>
     <WebPublishMethod>FileSystem</WebPublishMethod>
     <SiteUrlToLaunchAfterPublish />
   </PropertyGroup>


### PR DESCRIPTION
The `PublishUrl` for local-container development is incorrect.